### PR TITLE
Deactivate habs menu entry

### DIFF
--- a/server/config/envisage/apps.cfg
+++ b/server/config/envisage/apps.cfg
@@ -10,6 +10,6 @@
  <app id="erlangbackend"     src="./envisage/simulator/erlangbackend.cfg" />
  <app id="absoutline"        src="./envisage/outline/absoutline.cfg" />
  <app id="smartdeployer"     src="./envisage/smart_deployer/smart_deployer.cfg" />
- <app id="habs"              src="./envisage/habs/habs.cfg" />
- <app id="echo"              src="./default/echo.cfg" />
+ <!-- <app id="habs"              src="./envisage/habs/habs.cfg" /> -->
+<app id="echo"              src="./default/echo.cfg" />
 </apps>


### PR DESCRIPTION
- The haskell backend does not compile when setting up the container, so
  cannot be offered right now.